### PR TITLE
Return theory vector for cosmosis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Tests can be run using
 
 ## Step 2: download and unpack data
 
+This can be performed automatically with the supplied `get-act-data.sh` script. Otherwise follow the steps below.
+
 Download the likelihood data tarball for ACT DR6 lensing from [NASA's LAMBDA archive](https://lambda.gsfc.nasa.gov/product/act/actadv_prod_table.html).
 
 Extract the tarball into the `act_dr6_lenslike/data/` directory in the cloned repository such the directory `v1.1` is directly inside it. Only then should you proceed with the next steps.

--- a/act_dr6_lenslike/__init__.py
+++ b/act_dr6_lenslike/__init__.py
@@ -1,5 +1,5 @@
 """Likelihood for the Atacama Cosmology Telescope DR6 CMB lensing data."""
 __author__ = ["Mathew Madhavacheril", "Ian Harrison"]
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from .act_dr6_lenslike import *

--- a/act_dr6_lenslike/act_dr6_lenslike.py
+++ b/act_dr6_lenslike/act_dr6_lenslike.py
@@ -327,7 +327,7 @@ def load_data(variant, ddir=data_dir,
     return d
     
 
-def generic_lnlike(data_dict,ell_kk,cl_kk,ell_cmb,cl_tt,cl_ee,cl_te,cl_bb,trim_lmax = 2998):
+def generic_lnlike(data_dict,ell_kk,cl_kk,ell_cmb,cl_tt,cl_ee,cl_te,cl_bb,trim_lmax=2998,return_theory=False):
 
     cl_kk = standardize(ell_kk,cl_kk,trim_lmax)
     cl_tt = standardize(ell_cmb,cl_tt,trim_lmax)
@@ -344,7 +344,10 @@ def generic_lnlike(data_dict,ell_kk,cl_kk,ell_cmb,cl_tt,cl_ee,cl_te,cl_bb,trim_l
         bclkk = np.append(bclkk, d['binmat_planck'] @ clkk_planck)
     delta = d['data_binned_clkk'] - bclkk
     lnlike = -0.5 * np.dot(delta,np.dot(cinv,delta))
-    return lnlike
+    if return_theory:
+        lnlike, bclkk
+    else:
+        return lnlike
 
     
 # =================            


### PR DESCRIPTION
Joe requested here: https://github.com/joezuntz/cosmosis-standard-library/pull/104 that the bclkk theory vector is accesible by cosmosis for debugging.

I added an optional keyword to return it which I can use there, but shouldn't break anything anyone already has.

I also bumped the version as this should go on pypi for cosmosis to install.