### PR TITLE
version bump to 1.0.6

### DIFF
--- a/act_dr6_lenslike/__init__.py
+++ b/act_dr6_lenslike/__init__.py
@@ -1,5 +1,5 @@
 """Likelihood for the Atacama Cosmology Telescope DR6 CMB lensing data."""
 __author__ = ["Mathew Madhavacheril", "Ian Harrison"]
-__version__ = "1.0.5"
+__version__ = "1.0.6"
 
 from .act_dr6_lenslike import *


### PR DESCRIPTION
Just the version bump.

I feel like I'm still learning what a good workflow is for this kind of thing. I think(?) it is better to do version-bump-only commits like this, so they can be separated out from any actual development.

When this is merged I will tag the commit as a release, then publish the release on pypi.